### PR TITLE
Implement phylogenetic models

### DIFF
--- a/R/example_flocker_data.R
+++ b/R/example_flocker_data.R
@@ -9,7 +9,7 @@
 
 example_flocker_data <- function(rep_constant = FALSE, seed = 123) {
   if (!is.null(seed)) {set.seed(seed)}
-  n_pt <- 100
+  n_pt <- 30
   n_sp <- 30
   n_unit <- n_pt*n_sp
   n_rep <- 4

--- a/R/flock.R
+++ b/R/flock.R
@@ -68,6 +68,7 @@ flock <- function(f_occ, f_det, flocker_data, data2 = NULL,
     stanvars <- brms::stanvar(scode = make_occupancy_V_lpmf(max_rep = max_rep), block = "functions")
     flocker_fit <- brms::brm(f_use, 
                              data = flocker_data$data,
+                             data2 = data2,
                              family = occupancy_V(max_rep), 
                              stanvars = stanvars,
                              ...)
@@ -78,6 +79,7 @@ flock <- function(f_occ, f_det, flocker_data, data2 = NULL,
     stanvars <- brms::stanvar(scode = make_occupancy_C_lpmf(), block = "functions")
     flocker_fit <- brms::brm(brms::bf(f_use),
                              data = flocker_data$data,
+                             data2 = data2,
                              family = occupancy_C(),
                              stanvars = stanvars,
                              ...)

--- a/tests/testthat/test-make_flocker_data.R
+++ b/tests/testthat/test-make_flocker_data.R
@@ -9,17 +9,17 @@ test_that("make_flocker_data works correctly", {
   expect_equal(class(fd), c("list", "flocker_data"))
   expect_equal(names(fd), c("data", "max_rep", "type"))
   expect_equal(
-    sum(fd$data[1:3000, c("rep_index1", "rep_index2", 
+    sum(fd$data[1:900, c("rep_index1", "rep_index2", 
                           "rep_index3", "rep_index4")] - 
-          matrix(1:12000, ncol = 4)), 0)  
+          matrix(1:3600, ncol = 4)), 0)  
   expect_equal(names(fd$data), c("y", "uc1", "uc2", "grp", "species", "ec1", "ec2",
                                  "n_unit", "n_rep", "Q", "unit", "rep_index1", 
                                  "rep_index2", "rep_index3", "rep_index4"))
   expect_true(all(fd$data$occ %in% c(0,1,-99)))
   
-  event_covs[[1]] <- matrix(1:12000, ncol = 4)
+  event_covs[[1]] <- matrix(1:3600, ncol = 4)
   fd <- make_flocker_data(obs, unit_covs, event_covs)
-  expect_equal(fd$data$ec1, 1:12000)
+  expect_equal(fd$data$ec1, 1:3600)
   
   
   obs[2,4] <- NA
@@ -28,15 +28,15 @@ test_that("make_flocker_data works correctly", {
   expect_equal(class(fd), c("list", "flocker_data"))
   expect_equal(names(fd), c("data", "max_rep", "type"))
   expect_equal(
-    sum(fd$data[1:3000, c("rep_index1", "rep_index2", "rep_index3")] - 
-          matrix(1:9000, ncol = 3)), 0)
-  expect_equal(fd$data$rep_index4[1:3000], c(9001, -99, 9002:11999))
+    sum(fd$data[1:900, c("rep_index1", "rep_index2", "rep_index3")] - 
+          matrix(1:2700, ncol = 3)), 0)
+  expect_equal(fd$data$rep_index4[1:900], c(2701, -99, 2702:3599))
   expect_equal(names(fd$data), c("y", "uc1", "uc2", "grp", "species", "ec1", "ec2",
                                  "n_unit", "n_rep", "Q", "unit", "rep_index1", 
                                  "rep_index2", "rep_index3", "rep_index4"))
   expect_true(all(fd$flocker_data$occ %in% c(0,1,-99)))
-  expect_equal(fd$data$ec1[1:9000], 1:9000)
-  expect_equal(fd$data$ec1[9001:11999], c(9001, 9003:12000))
+  expect_equal(fd$data$ec1[1:2700], 1:2700)
+  expect_equal(fd$data$ec1[2701:3599], c(2701, 2703:3600))
   
   obs[,4] <- NA
   expect_error(fd <- make_flocker_data(obs),

--- a/vignettes/flocker_tutorial.Rmd
+++ b/vignettes/flocker_tutorial.Rmd
@@ -106,7 +106,27 @@ flock(f_occ = ~ s(uc1),
 `brms` is capable of fitting a variety of additional effects structures. We believe that the following structures should translate directly to `flocker`, but these remain untested. As we test them and verify adequate performance, we will update this vignette with examples.
 
 #### Phylogenetic models
-[See here](https://paul-buerkner.github.io/brms/articles/brms_phylogenetics.html) for details about specifying details of phylogenetic effects in `brms`. Note that `flock()` directly accepts a `data2` argument that it can pass to `brms` as necessary.
+Phylogenetic effects can be included by providing a covariance matrix as a `data2` argument and using the `gr()` function to link species identities in `flocker_data` with the supplied covariance matrix. Note that phylogenetic effects can be included in either the occupancy component, the detection component, or both! 
+```{r, phylo, eval=FALSE} 
+# simulate an example phylogeny
+phylogeny <- ape::rtree(30, tip.label = paste0("sp_", 1:30))
+
+# calculate covariance matrix
+A <- ape::vcv.phylo(phylogeny)
+
+ff1 <- flock(f_occ = ~ 1 + (1|gr(species, cov = A)), 
+             f_det = ~  1 + ec1 + (1|species), 
+             flocker_data = flocker_data, 
+             data2 = list(A = A))
+
+ff2 <- flock(f_occ = ~ 1 + (1|gr(species, cov = A)), 
+             f_det = ~  1 + ec1 + (1|gr(species, cov = A)), 
+             flocker_data = flocker_data, 
+             data2 = list(A = A))
+
+```
+
+[See here](https://paul-buerkner.github.io/brms/articles/brms_phylogenetics.html) for further details about specifying phylogenetic effects in `brms`.
 
 #### Spatial autoregressive models
 [See here](https://paul-buerkner.github.io/brms/reference/car.html) for details about conditional autoregressive (CAR) models in `brms`. Note that if the spatial effect is applied to occupancy, it is essential closure-units be grouped such that many groups contain more than one unit. With just one unit per group (the `brms` default if no grouping is supplied), the logit-scale residual is not identified. Note that `flock()` directly accepts a `data2` argument that it can pass to `brms` as necessary.
@@ -130,13 +150,13 @@ user_prior <- c(brms::set_prior("normal(0, 3)", class="b"),
 
 ff <- flock(f_occ = ~ uc1 + uc2 + (1|species), 
             f_det = ~  ec1 + ec2 + (1|species), 
-            flocker_data = fd, 
+            flocker_data = flocker_data, 
             prior = user_prior)
 
 brms::prior_summary(ff)
 ```
 
-Note: if there are parameters shared between both the occupancy and detection model formulas, e.g. 
+Note that if there are parameters shared between both the occupancy and detection model formulas, e.g. 
 ```{r, priors_2, eval=FALSE}
 ff <- flock(f_occ = ~ uc1 + (1|species), 
               f_det = ~  uc1 + ec2 + (1|species), 


### PR DESCRIPTION
1. Reduce number of points in example_flocker_data from 100 to 30 (100 is arbitrary, and 30 enables example models to be run quicker while still being enough points to make sensible inference). 
2. Fix `flock()` so that it receives data2 arguments. 
3.  Added phylogenetic model example to tutorial
4.  edited testthat to pass following changes to example_flocker_data()