### PR TITLE
added functionality for running loo on a thinned object

### DIFF
--- a/R/log_lik_occupancy.R
+++ b/R/log_lik_occupancy.R
@@ -12,6 +12,8 @@ log_lik_V <- function(flocker_fit_V, draw_ids = NULL) {
     stop("flocker_fit_V works only for rep-varying flocker_fits")
   }
 
+  if(is.null(draw_ids)) draw_ids <- 1:brms::ndraws(flocker_fit_V)
+  
   # dimensions
   n_unit <- flocker_fit_V$data$n_unit[1]
   ndraws <- length(draw_ids)
@@ -65,7 +67,6 @@ log_lik_V <- function(flocker_fit_V, draw_ids = NULL) {
   
   return(log_lik_mat)
 }
-
 
 #' Compute the part of the log-likelihood relating to sampling events. To be used 
 #' internally in log_lik_V(). Missing events are returned as 0s

--- a/R/log_lik_occupancy.R
+++ b/R/log_lik_occupancy.R
@@ -13,7 +13,7 @@ log_lik_V <- function(flocker_fit_V, draw_ids = NULL) {
   }
 
   if(is.null(draw_ids)) draw_ids <- 1:brms::ndraws(flocker_fit_V)
-  
+    
   # dimensions
   n_unit <- flocker_fit_V$data$n_unit[1]
   ndraws <- length(draw_ids)
@@ -67,6 +67,7 @@ log_lik_V <- function(flocker_fit_V, draw_ids = NULL) {
   
   return(log_lik_mat)
 }
+
 
 #' Compute the part of the log-likelihood relating to sampling events. To be used 
 #' internally in log_lik_V(). Missing events are returned as 0s

--- a/R/log_lik_occupancy.R
+++ b/R/log_lik_occupancy.R
@@ -1,5 +1,6 @@
 #' Compute unitwise log-likelihood matrix for a rep-varying flocker_fit object
 #' @param flocker_fit_V A rep-varying flocker_fit object
+#' @param draw_ids the draw ids to compute log-likelihoods for. Defaults to using the full posterior. 
 #' @return A unitwise posterior log-likelihood matrix
 #' @export
 

--- a/R/log_lik_occupancy.R
+++ b/R/log_lik_occupancy.R
@@ -3,24 +3,24 @@
 #' @return A unitwise posterior log-likelihood matrix
 #' @export
 
-log_lik_V <- function(flocker_fit_V) {
+log_lik_V <- function(flocker_fit_V, draw_ids = NULL) {
   if (!("flocker_fit" %in% class(flocker_fit_V))) {
     stop("flocker_fit_V must be an object of class flocker_fit.")
   }
   if (type_flocker_fit(flocker_fit_V) != "V") {
     stop("flocker_fit_V works only for rep-varying flocker_fits")
   }
-  
+
   # dimensions
   n_unit <- flocker_fit_V$data$n_unit[1]
+  ndraws <- length(draw_ids)
   max_rep <- max(flocker_fit_V$data$n_rep)
-  n_iter <- prod(dim(flocker_fit_V$fit)[1:2])
   
   rep_index_matrix <- 
     as.matrix(flocker_fit_V$data[1:n_unit, grepl("rep_index", names(flocker_fit_V$data))])
   
-  lpo_t <- t(brms::posterior_linpred(flocker_fit_V, dpar = "occ"))
-  lpd_t <- t(brms::posterior_linpred(flocker_fit_V, dpar = "mu"))
+  lpo_t <- t(brms::posterior_linpred(flocker_fit_V, dpar = "occ", draw_ids = draw_ids))
+  lpd_t <- t(brms::posterior_linpred(flocker_fit_V, dpar = "mu", draw_ids = draw_ids))
   
   # create long-format dataframe (with iterations stacked down rows)
   # note: missed reps are inserted as -99s
@@ -28,8 +28,8 @@ log_lik_V <- function(flocker_fit_V) {
                           unit_index = rep(1:n_unit, max_rep), 
                           rep_index = c(rep_index_matrix),
                           Q = rep(flocker_fit_V$data$Q[1:n_unit], max_rep), 
-                          # note: everything above this is getting duplicated n_iter times
-                          iter = rep(1:n_iter, each = n_unit*max_rep), 
+                          # note: everything above this is getting duplicated ndraws times
+                          draw_id = rep(draw_ids, each = n_unit*max_rep), 
                           lpo = NA, 
                           lpd = NA)
   all_iters$resp[all_iters$rep_index != -99] <- flocker_fit_V$data$y
@@ -40,14 +40,14 @@ log_lik_V <- function(flocker_fit_V) {
   all_iters$ll <- calc_log_lik_partial(all_iters$resp, all_iters$Q, all_iters$lpd)
   
   # spread this to wide format (i.e. 1 column per rep)
-  rep_index <- rep(rep(1:max_rep, each=n_unit), n_iter)
+  rep_index <- rep(rep(1:max_rep, each=n_unit), ndraws)
   
   ll_partial_V <- do.call("cbind", 
                           lapply(1:max_rep, function(x) matrix(all_iters$ll[rep_index == x])))
   
-  ll_partial_S <- data.frame(Q = rep(all_iters$Q[1:n_unit], n_iter),
+  ll_partial_S <- data.frame(Q = rep(all_iters$Q[1:n_unit], ndraws),
                              lpo = all_iters$lpo[rep_index == 1], # note: duplicated across reps 
-                             iter = all_iters$iter[rep_index == 1]) 
+                             draw_id = all_iters$draw_id[rep_index == 1]) 
   
   # finish likelihood calculation
   Q_index <- as.logical(ll_partial_S$Q)
@@ -59,7 +59,8 @@ log_lik_V <- function(flocker_fit_V) {
           log_inv_logit(ll_partial_S$lpo[!Q_index]) + rowSums(ll_partial_V[!Q_index,])))
   
   # unstack to matrix [n_iter, n_unit]
-  log_lik_mat <- t(unstack(ll_partial_S[c("log_lik", "iter")], log_lik ~ iter))
+  log_lik_mat <- t(unstack(ll_partial_S[c("log_lik", "draw_id")], log_lik ~ draw_id))
+  row.names(log_lik_mat) <- gsub("X", "", row.names(log_lik_mat))
   
   return(log_lik_mat)
 }

--- a/R/loo.R
+++ b/R/loo.R
@@ -69,7 +69,7 @@ loo_flocker_onefit <- function(x, thin = NULL) {
 }
 
 #' LOO comparisons for flocker models. 
-#' @param x a list of flocker_fit objects.
+#' @param model_list a list of flocker_fit objects.
 #' @param thin specify the amount of thinning required. 1 or NULL implies no thinning, 2 implies every other value, 3 every third, etc.
 #' @param model_names An optional vector of names for the models.
 #' @export

--- a/R/loo.R
+++ b/R/loo.R
@@ -1,5 +1,6 @@
 #' Compute loo for flocker_fit objects
 #' @param x a flocker_fit object or a list of flocker_fit objects
+#' @param thin specify the amount of thinning required. 1 or NULL implies no thinning, 2 implies every other value, 3 every third, etc.
 #' @return a loo object or a list of loo objects
 #' @export
 
@@ -30,6 +31,7 @@ loo_flocker <- function(x, thin = NULL) {
 
 #' Compute loo for a single flocker_fit object
 #' @param x a flocker_fit object
+#' @param thin specify the amount of thinning required. 1 or NULL implies no thinning, 2 implies every other value, 3 every third, etc.
 #' @return a loo object
 
 loo_flocker_onefit <- function(x, thin = NULL) {
@@ -68,6 +70,7 @@ loo_flocker_onefit <- function(x, thin = NULL) {
 
 #' LOO comparisons for flocker models. 
 #' @param x a list of flocker_fit objects.
+#' @param thin specify the amount of thinning required. 1 or NULL implies no thinning, 2 implies every other value, 3 every third, etc.
 #' @param model_names An optional vector of names for the models.
 #' @export
 

--- a/R/loo.R
+++ b/R/loo.R
@@ -74,14 +74,14 @@ loo_flocker_onefit <- function(x, thin = NULL) {
 #' @param model_names An optional vector of names for the models.
 #' @export
 
-loo_compare_flocker <- function(x, model_names = NULL, thin = NULL) {
-  if (!("list" %in% class(x))) {
-    stop("x must be a list of flocker_fit objects.")
+loo_compare_flocker <- function(model_list, model_names = NULL, thin = NULL) {
+  if (!("list" %in% class(model_list))) {
+    stop("model_list must be a list of flocker_fit objects.")
   }
-  if (length(x) < 2L) {
-    stop("x must contain at least two flocker_fit objects.")
+  if (length(model_list) < 2L) {
+    stop("model_list must contain at least two flocker_fit objects.")
   }
-  occupancy_loo <- loo_flocker(x, thin = thin)
+  occupancy_loo <- loo_flocker(model_list, thin = thin)
   if (!is.null(model_names)) {
     names(occupancy_loo) <- model_names
   }

--- a/man/log_lik_V.Rd
+++ b/man/log_lik_V.Rd
@@ -4,10 +4,12 @@
 \alias{log_lik_V}
 \title{Compute unitwise log-likelihood matrix for a rep-varying flocker_fit object}
 \usage{
-log_lik_V(flocker_fit_V)
+log_lik_V(flocker_fit_V, draw_ids = NULL)
 }
 \arguments{
 \item{flocker_fit_V}{A rep-varying flocker_fit object}
+
+\item{draw_ids}{the draw ids to compute log-likelihoods for. Defaults to using the full posterior.}
 }
 \value{
 A unitwise posterior log-likelihood matrix

--- a/man/loo_compare_flocker.Rd
+++ b/man/loo_compare_flocker.Rd
@@ -4,10 +4,10 @@
 \alias{loo_compare_flocker}
 \title{LOO comparisons for flocker models.}
 \usage{
-loo_compare_flocker(x, model_names = NULL, thin = NULL)
+loo_compare_flocker(model_list, model_names = NULL, thin = NULL)
 }
 \arguments{
-\item{x}{a list of flocker_fit objects.}
+\item{model_list}{a list of flocker_fit objects.}
 
 \item{model_names}{An optional vector of names for the models.}
 

--- a/man/loo_compare_flocker.Rd
+++ b/man/loo_compare_flocker.Rd
@@ -4,12 +4,14 @@
 \alias{loo_compare_flocker}
 \title{LOO comparisons for flocker models.}
 \usage{
-loo_compare_flocker(x, model_names = NULL)
+loo_compare_flocker(x, model_names = NULL, thin = NULL)
 }
 \arguments{
 \item{x}{a list of flocker_fit objects.}
 
 \item{model_names}{An optional vector of names for the models.}
+
+\item{thin}{specify the amount of thinning required. 1 or NULL implies no thinning, 2 implies every other value, 3 every third, etc.}
 }
 \description{
 LOO comparisons for flocker models.

--- a/man/loo_flocker.Rd
+++ b/man/loo_flocker.Rd
@@ -4,10 +4,12 @@
 \alias{loo_flocker}
 \title{Compute loo for flocker_fit objects}
 \usage{
-loo_flocker(x)
+loo_flocker(x, thin = NULL)
 }
 \arguments{
 \item{x}{a flocker_fit object or a list of flocker_fit objects}
+
+\item{thin}{specify the amount of thinning required. 1 or NULL implies no thinning, 2 implies every other value, 3 every third, etc.}
 }
 \value{
 a loo object or a list of loo objects

--- a/man/loo_flocker_onefit.Rd
+++ b/man/loo_flocker_onefit.Rd
@@ -4,10 +4,12 @@
 \alias{loo_flocker_onefit}
 \title{Compute loo for a single flocker_fit object}
 \usage{
-loo_flocker_onefit(x)
+loo_flocker_onefit(x, thin = NULL)
 }
 \arguments{
 \item{x}{a flocker_fit object}
+
+\item{thin}{specify the amount of thinning required. 1 or NULL implies no thinning, 2 implies every other value, 3 every third, etc.}
 }
 \value{
 a loo object

--- a/tests/testthat/test-log_lik_V.R
+++ b/tests/testthat/test-log_lik_V.R
@@ -1,0 +1,18 @@
+test_that("check log_lik_V works correctly", {
+  # read test-case flocker fit
+  test_fit <- readRDS("../test_data/test_fit.rds")
+
+  # check dims
+  ll_test <- log_lik_V(test_fit)
+  expect_equal(dim(ll_test), c(1000, 50))
+  ll_test <- log_lik_V(test_fit, draw_ids = 1:50)
+  expect_equal(dim(ll_test), c(50, 50))
+  
+  # check classes
+  expect_equal(class(ll_test), c("matrix", "array"))
+  expect_equal(class(ll_test[1]), "numeric")
+  
+  # check rep-constant error
+  attributes(test_fit)$lik_type <- "C"
+  expect_error(log_lik_V(test_fit), "flocker_fit_V works only for rep-varying flocker_fits")
+})

--- a/tests/testthat/test-log_lik_V.R
+++ b/tests/testthat/test-log_lik_V.R
@@ -12,8 +12,8 @@ test_that("check log_lik_V works correctly", {
   expect_equal(class(ll_test), c("matrix", "array"))
   expect_equal(class(as.vector(ll_test)), "numeric")
   expect_lte(max(ll_test), 0)
-  any(is.infinite(ll_test), FALSE)
-  any(is.na(ll_test), FALSE)
+  expect_false(any(is.infinite(ll_test)))
+  expect_false(any(is.na(ll_test)))
   
   # check rep-constant error
   attributes(test_fit)$lik_type <- "C"

--- a/tests/testthat/test-log_lik_V.R
+++ b/tests/testthat/test-log_lik_V.R
@@ -8,9 +8,12 @@ test_that("check log_lik_V works correctly", {
   ll_test <- log_lik_V(test_fit, draw_ids = 1:50)
   expect_equal(dim(ll_test), c(50, 50))
   
-  # check classes
+  # check classes/values
   expect_equal(class(ll_test), c("matrix", "array"))
-  expect_equal(class(ll_test[1]), "numeric")
+  expect_equal(class(as.vector(ll_test)), "numeric")
+  expect_lte(max(ll_test), 0)
+  any(is.infinite(ll_test), FALSE)
+  any(is.na(ll_test), FALSE)
   
   # check rep-constant error
   attributes(test_fit)$lik_type <- "C"

--- a/tests/testthat/test-loo_compare_flocker.R
+++ b/tests/testthat/test-loo_compare_flocker.R
@@ -1,0 +1,15 @@
+test_that("loo_flocker_onefit works correctly", {
+  # read test-case flocker fit
+  test_fit <- readRDS("../test_data/test_fit.rds")
+  
+  # check error
+  expect_error(loo_compare_flocker(test_fit), "model_list must be a list of flocker_fit objects.")
+  expect_error(loo_compare_flocker(list(test_fit)), "model_list must contain at least two flocker_fit objects.")
+
+  # check model naming
+  test_compare <- loo_compare_flocker(list(test_fit, test_fit), model_names = c("m1", "m2"))
+  expect_identical(row.names(test_compare), c("m1", "m2"))
+  
+  # check test output identical
+  expect_true(all(apply(test_compare, 2, diff) == 0))
+})

--- a/tests/testthat/test-loo_flocker.R
+++ b/tests/testthat/test-loo_flocker.R
@@ -17,7 +17,7 @@ test_that("loo_flocker_onefit works correctly", {
   expect_equal(attributes(test_loo_thinned)$dims, c(200, 50))
   
   # check list output
-  expect_identical(class(test_compare), "list")
-  expect_identical(test_compare[[1]], test_compare[[2]])
+  expect_identical(class(test_loo_list), "list")
+  expect_identical(test_loo_list[[1]], test_loo_list[[2]])
   expect_identical(test_loo_list[[1]], test_loo)
 })

--- a/tests/testthat/test-loo_flocker.R
+++ b/tests/testthat/test-loo_flocker.R
@@ -1,0 +1,23 @@
+test_that("loo_flocker_onefit works correctly", {
+  # read test-case flocker fit
+  test_fit <- readRDS("../test_data/test_fit.rds")
+  
+  test_loo <- loo_flocker(test_fit)
+  test_loo_thinned <- loo_flocker(test_fit, 5)
+  test_loo_list <- loo_flocker(list(test_fit, test_fit))
+  
+  # check error
+  expect_error(loo_flocker(), "argument \"x\" is missing, with no default")
+  expect_error(loo_flocker(1), "x must be a flocker_fit object or a list of flocker_fit objects")
+  expect_error(loo_flocker(list(1)), "x is a list, but x\\[\\[1\\]\\] is not a flocker_fit object.")
+  expect_error(loo_flocker(list(test_fit, 1)), "x is a list, but x\\[\\[2\\]\\] is not a flocker_fit object.")
+  
+  # check dims
+  expect_equal(attributes(test_loo)$dims, c(1000, 50))
+  expect_equal(attributes(test_loo_thinned)$dims, c(200, 50))
+  
+  # check list output
+  expect_identical(class(test_compare), "list")
+  expect_identical(test_compare[[1]], test_compare[[2]])
+  expect_identical(test_loo_list[[1]], test_loo)
+})

--- a/tests/testthat/test-loo_flocker_onefit.R
+++ b/tests/testthat/test-loo_flocker_onefit.R
@@ -1,0 +1,18 @@
+test_that("loo_flocker_onefit works correctly", {
+  # read test-case flocker fit
+  test_fit <- readRDS("../test_data/test_fit.rds")
+  
+  # check error
+  expect_error(loo_flocker_onefit(1), "x must be a flocker_fit object")
+  
+  test_loo <- loo_flocker_onefit(test_fit, thin = NULL)
+  test_loo_alt <- loo_flocker_onefit(test_fit, thin=1)
+  test_loo_thinned <- loo_flocker_onefit(test_fit, thin = 5)
+  
+  # check dimensions
+  expect_equal(attributes(test_loo)$dims, c(1000, 50))
+  expect_equal(attributes(test_loo_thinned)$dims, c(200, 50))
+  
+  # check thin = NULL specification returns same output 
+  expect_identical(test_loo, test_loo_alt)
+})


### PR DESCRIPTION
Necessary for reducing memory overhead on v. large models. loo functions have a thin argument; `log_lik_V()` has a `draw_ids` argument, which are passed from the loo functions. When you provide loo with a single model, it also returns the dimensions of the log_lik matrix it has generated them from. loo_compare_flocker doesn't, and it would be good to add this at some point (given you can now calculate over a thinned matrix). 

edit: also added unit tests for loo functions and `log_lik_V()`