### PR TITLE
Upcoming breaking changes in `loo_compare()` output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 * dramatically improved efficiency in certain post-processing functions for multiseason models
 * CI runs properly
 * backend hygiene improvements
+* updated compatibility with upcoming changes to `loo_compare()` output
+  structure in the `loo` package (> 2.9.0), which now returns a data frame
+  instead of a matrix and includes additional diagnostic columns.
 
 # flocker 1.0-1
 * fixed a bug that was throwing an uninformative error when making predictions in multiseason models where history_condition is TRUE

--- a/R/loo.R
+++ b/R/loo.R
@@ -63,7 +63,7 @@ loo_flocker_onefit <- function(x, thin = NULL) {
 #' @param thin specify the amount of thinning required. 1 or NULL results in no 
 #'    thinning, 2 retains every other value, 3 every third, etc.
 #' @param model_names An optional vector of names for the models.
-#' @return a `compare.loo` matrix
+#' @return a `compare.loo` object
 #' @export
 #' @examples
 #' \dontrun{

--- a/man/loo_compare_flocker.Rd
+++ b/man/loo_compare_flocker.Rd
@@ -15,7 +15,7 @@ loo_compare_flocker(model_list, model_names = NULL, thin = NULL)
 thinning, 2 retains every other value, 3 every third, etc.}
 }
 \value{
-a `compare.loo` matrix
+a `compare.loo` object
 }
 \description{
 LOO comparisons for flocker models.

--- a/tests/testthat/test-loo_flocker.R
+++ b/tests/testthat/test-loo_flocker.R
@@ -43,8 +43,16 @@ test_that("loo_compare_flocker works correctly", {
   # check model naming
   suppressWarnings(test_compare <- loo_compare_flocker(list(example_flocker_model_single2, example_flocker_model_single2), 
                                       model_names = c("m1", "m2"), thin = 2))
-  expect_identical(row.names(test_compare), c("m1", "m2"))
+  if ("model" %in% colnames(test_compare)) {
+    expect_identical(test_compare$model, c("m1", "m2"))
+  } else {
+    expect_identical(row.names(test_compare), c("m1", "m2"))
+  }
   
   # check test output identical
-  expect_true(all(apply(test_compare, 2, diff) == 0))
+  if ("model" %in% colnames(test_compare)) {
+    expect_true(all(apply(test_compare[,c(2,3)], 2, diff) == 0))
+  } else {
+    expect_true(all(apply(test_compare, 2, diff) == 0))
+  }
 })

--- a/vignettes/flocker_tutorial.Rmd
+++ b/vignettes/flocker_tutorial.Rmd
@@ -471,18 +471,11 @@ model.
 loo_compare_flocker(
   list(rep_constant, rep_varying)
 )
-#> Warning messages:
-#> 1: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
-
-#> 2: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
-
-#>   model elpd_diff se_diff p_worse diag_diff      diag_elpd
-#>  model2       0.0     0.0      NA           2 k_psis > 0.7
-#>  model1    -169.5    17.2    1.00           1 k_psis > 0.7
-
-#> Diagnostic flags present.
-#> See ?`loo-glossary` (sections `diag_diff` and `diag_elpd`)
-#> or https://mc-stan.org/loo/reference/loo-glossary.html.
+#> Warning: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
+#> Warning: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
+#>        elpd_diff se_diff
+#> model2    0.0       0.0 
+#> model1 -121.0      16.1
 ```
 
 Likewise, we can compare the four flavors of multi-season model that we fit 
@@ -496,11 +489,11 @@ performs best:
 loo_compare_flocker(
   list(multi_colex, multi_colex_eq, multi_auto, multi_auto_eq)
 )
-#>   model elpd_diff se_diff p_worse diag_diff diag_elpd
-#>  model1       0.0     0.0      NA
-#>  model3      -8.0     4.1    0.98
-#>  model2     -27.1     7.2    1.00
-#>  model4     -32.9     7.8    1.00
+#>        elpd_diff se_diff
+#> model1   0.0       0.0  
+#> model2 -16.5       6.2  
+#> model3 -41.7       9.5  
+#> model4 -57.5      10.8
 ```
 
 Flocker also provides the function `loo_flocker()` to return a table of 

--- a/vignettes/flocker_tutorial.Rmd
+++ b/vignettes/flocker_tutorial.Rmd
@@ -471,11 +471,18 @@ model.
 loo_compare_flocker(
   list(rep_constant, rep_varying)
 )
-#> Warning: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
-#> Warning: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
-#>        elpd_diff se_diff
-#> model2    0.0       0.0 
-#> model1 -121.0      16.1
+#> Warning messages:
+#> 1: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
+
+#> 2: Some Pareto k diagnostic values are too high. See help('pareto-k-diagnostic') for details.
+
+#>   model elpd_diff se_diff p_worse diag_diff      diag_elpd
+#>  model2       0.0     0.0      NA           2 k_psis > 0.7
+#>  model1    -169.5    17.2    1.00           1 k_psis > 0.7
+
+#> Diagnostic flags present.
+#> See ?`loo-glossary` (sections `diag_diff` and `diag_elpd`)
+#> or https://mc-stan.org/loo/reference/loo-glossary.html.
 ```
 
 Likewise, we can compare the four flavors of multi-season model that we fit 
@@ -489,11 +496,11 @@ performs best:
 loo_compare_flocker(
   list(multi_colex, multi_colex_eq, multi_auto, multi_auto_eq)
 )
-#>        elpd_diff se_diff
-#> model1   0.0       0.0  
-#> model2 -16.5       6.2  
-#> model3 -41.7       9.5  
-#> model4 -57.5      10.8
+#>   model elpd_diff se_diff p_worse diag_diff diag_elpd
+#>  model1       0.0     0.0      NA
+#>  model3      -8.0     4.1    0.98
+#>  model2     -27.1     7.2    1.00
+#>  model4     -32.9     7.8    1.00
 ```
 
 Flocker also provides the function `loo_flocker()` to return a table of 


### PR DESCRIPTION
## Description
In the `loo` package, we are making changes to the output structure returned by `loo_compare()` in [PR #300](https://github.com/stan-dev/loo/pull/300). The main changes are a transition from a matrix to a data frame and the addition of several new columns. Here is an example of the updated output structure:

```
> loo_compare(w1, w2)
  model elpd_diff se_diff p_worse diag_diff diag_elpd
 model1       0.0     0.0      NA                    
 model2      -4.1     0.1    1.00   N < 100     
     
Diagnostic flags present.
See ?`loo-glossary` (sections `diag_diff` and `diag_elpd`)
or https://mc-stan.org/loo/reference/loo-glossary.html.
```

More context on the motivation behind these changes can be found in the updated case study ["Uncertainty in Bayesian LOO-CV Model Comparison"](https://users.aalto.fi/~ave/casestudies/LOO_uncertainty/loo_uncertainty.html).

A **reverse dependency check revealed that these changes will affect your package**. To help smooth the transition, I have already reviewed your code and suggest within this PR changes that should keep your package compatible with both the current and the upcoming `loo_compare()` output structure.

I may have missed some additional spots in your code that need updating, so please feel free to point those out and I am happy to help. Thank you and please do not hesitate to reach out if you have any questions or concerns.

## TODO
+ [ ] I noticed one aspect related to `flocker_tutorial.Rmd` where I am uncertain how you want to handle this. In the section "Post-processing > Model comparison" you currently provide the expected output in form of a comment. This expected output will change for the new `loo_compare()` function. 

